### PR TITLE
NCSLT-409 implementing HTTP Client Factory changes in additional places

### DIFF
--- a/DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests/DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.csproj
+++ b/DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests/DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests/Services/HttpClientServiceDeleteTests.cs
+++ b/DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests/Services/HttpClientServiceDeleteTests.cs
@@ -3,6 +3,7 @@ using DFC.App.JobProfileTasks.MessageFunctionApp.Services;
 using DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.ClientHandlers;
 using DFC.Logger.AppInsights.Contracts;
 using FakeItEasy;
+using Moq;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -16,6 +17,8 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
         private readonly ILogService logger;
         private readonly JobProfileClientOptions segmentClientOptions;
         private readonly ICorrelationIdProvider correlationIdProvider;
+        private Mock<IHttpClientFactory> mockFactory;
+
 
         public HttpClientServiceDeleteTests()
         {
@@ -28,6 +31,13 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             correlationIdProvider = A.Fake<ICorrelationIdProvider>();
         }
 
+        public Mock<IHttpClientFactory> CreateClientFactory(HttpClient httpClient)
+        {
+            mockFactory = new Mock<IHttpClientFactory>();
+            mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            return mockFactory;
+        }
+
         [Fact]
         public async Task DeleteAsyncReturnsOkStatusCodeForExistingId()
         {
@@ -37,7 +47,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = segmentClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(segmentClientOptions, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(segmentClientOptions, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -62,7 +72,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = segmentClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(segmentClientOptions, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(segmentClientOptions, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -87,7 +97,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = segmentClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(segmentClientOptions, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(segmentClientOptions, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 

--- a/DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests/Services/HttpClientServicePatchTests.cs
+++ b/DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests/Services/HttpClientServicePatchTests.cs
@@ -4,6 +4,7 @@ using DFC.App.JobProfileTasks.MessageFunctionApp.Services;
 using DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.ClientHandlers;
 using DFC.Logger.AppInsights.Contracts;
 using FakeItEasy;
+using Moq;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -14,6 +15,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
 {
     public class HttpClientServicePatchTests
     {
+        private Mock<IHttpClientFactory> mockFactory;
         private readonly ILogService logger;
         private readonly JobProfileClientOptions segmentClientOptions;
         private readonly ICorrelationIdProvider correlationIdProvider;
@@ -29,6 +31,13 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             correlationIdProvider = A.Fake<ICorrelationIdProvider>();
         }
 
+        public Mock<IHttpClientFactory> CreateClientFactory(HttpClient httpClient)
+        {
+            mockFactory = new Mock<IHttpClientFactory>();
+            mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            return mockFactory;
+        }
+
         [Fact]
         public async Task PatchAsyncReturnsOkStatusCodeForExistingId()
         {
@@ -38,7 +47,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = segmentClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(segmentClientOptions, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(segmentClientOptions, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -63,7 +72,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = segmentClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(segmentClientOptions, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(segmentClientOptions, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -88,7 +97,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = segmentClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(segmentClientOptions, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(segmentClientOptions, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 

--- a/DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests/Services/HttpClientServicePostTests.cs
+++ b/DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests/Services/HttpClientServicePostTests.cs
@@ -4,6 +4,7 @@ using DFC.App.JobProfileTasks.MessageFunctionApp.Services;
 using DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.ClientHandlers;
 using DFC.Logger.AppInsights.Contracts;
 using FakeItEasy;
+using Moq;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -17,6 +18,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
         private readonly ILogService logger;
         private readonly JobProfileClientOptions segmentClientOptions;
         private readonly ICorrelationIdProvider correlationIdProvider;
+        private Mock<IHttpClientFactory> mockFactory;
 
         public HttpClientServicePostTests()
         {
@@ -29,6 +31,13 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             correlationIdProvider = A.Fake<ICorrelationIdProvider>();
         }
 
+        public Mock<IHttpClientFactory> CreateClientFactory(HttpClient httpClient)
+        {
+            mockFactory = new Mock<IHttpClientFactory>();
+            mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            return mockFactory;
+        }
+
         [Fact]
         public async Task PostFullJobProfileAsyncReturnsOkStatusCodeForExistingId()
         {
@@ -38,7 +47,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = segmentClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(segmentClientOptions, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(segmentClientOptions, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -63,7 +72,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = segmentClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(segmentClientOptions, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(segmentClientOptions, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 

--- a/DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests/Services/HttpClientServicePutTests.cs
+++ b/DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests/Services/HttpClientServicePutTests.cs
@@ -4,6 +4,7 @@ using DFC.App.JobProfileTasks.MessageFunctionApp.Services;
 using DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.ClientHandlers;
 using DFC.Logger.AppInsights.Contracts;
 using FakeItEasy;
+using Moq;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -14,6 +15,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
 {
     public class HttpClientServicePutTests
     {
+        private Mock<IHttpClientFactory> mockFactory;
         private readonly ILogService logger;
         private readonly JobProfileClientOptions segmentClientOptions;
         private readonly ICorrelationIdProvider correlationIdProvider;
@@ -29,6 +31,13 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             correlationIdProvider = A.Fake<ICorrelationIdProvider>();
         }
 
+        public Mock<IHttpClientFactory> CreateClientFactory(HttpClient httpClient)
+        {
+            mockFactory = new Mock<IHttpClientFactory>();
+            mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            return mockFactory;
+        }
+
         [Fact]
         public async Task PutFullJobProfileAsyncReturnsOkStatusCodeForExistingId()
         {
@@ -38,7 +47,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = segmentClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(segmentClientOptions, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(segmentClientOptions, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -63,7 +72,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = segmentClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(segmentClientOptions, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(segmentClientOptions, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -88,7 +97,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = segmentClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(segmentClientOptions, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(segmentClientOptions, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 

--- a/DFC.App.JobProfileTasks.MessageFunctionApp/Services/HttpClientService.cs
+++ b/DFC.App.JobProfileTasks.MessageFunctionApp/Services/HttpClientService.cs
@@ -19,10 +19,10 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp.Services
         private readonly ILogService logger;
         private readonly ICorrelationIdProvider correlationIdProvider;
 
-        public HttpClientService(JobProfileClientOptions jobProfileClientOptions, HttpClient httpClient, ILogService logger, ICorrelationIdProvider correlationIdProvider)
+        public HttpClientService(JobProfileClientOptions jobProfileClientOptions, IHttpClientFactory httpClientFactory, ILogService logger, ICorrelationIdProvider correlationIdProvider)
         {
             this.jobProfileClientOptions = jobProfileClientOptions;
-            this.httpClient = httpClient;
+            this.httpClient = httpClientFactory.CreateClient();
             this.logger = logger;
             this.correlationIdProvider = correlationIdProvider;
         }

--- a/DFC.App.JobProfileTasks.MessageFunctionApp/Startup.cs
+++ b/DFC.App.JobProfileTasks.MessageFunctionApp/Startup.cs
@@ -36,7 +36,7 @@ namespace DFC.App.JobProfileTasks.MessageFunctionApp
             builder?.Services.AddAutoMapper(typeof(Startup).Assembly);
             builder?.Services.AddTransient<IMessagePreProcessor, MessagePreProcessor>();
             builder?.Services.AddTransient<IMessageProcessor, MessageProcessor>();
-            builder?.Services.AddTransient(provider => new HttpClient());
+            builder?.Services.AddHttpClient();
             builder?.Services.AddScoped<IHttpClientService, HttpClientService>();
             builder?.Services.AddSingleton<IMappingService, MappingService>();
             builder?.Services.AddSingleton<IMessagePropertiesService, MessagePropertiesService>();


### PR DESCRIPTION
Use IHttpClientFactory instead of instantiating HttpClient class for each request.